### PR TITLE
Fix archive segment replication failure caused by refresh in short time leading to contention metadata update

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveReplicationIT.java
@@ -470,6 +470,111 @@ public class SegmentArchiveReplicationIT extends RemoteStoreBaseIntegTestCase {
     }
 
     /**
+     * Regression test: rapid indexing with 1s refresh_interval and segment archive upload
+     * must not produce CorruptIndexException on the replica.
+     *
+     * <p><b>Root cause:</b> Each metadata file stores one {@code archiveBlob} name and one set
+     * of {@code archiveEntries} — the entries of the <em>latest</em> archive only. After
+     * multiple flush+refresh cycles, segment files span <em>multiple</em> archive blobs
+     * (A1, A2, A3, …). When the replica calls {@code init()} on its
+     * {@code RemoteSegmentStoreDirectory}, the loaded {@code archiveState.entries} only
+     * contains entries for the latest archive (e.g., A3). Files that were uploaded in older
+     * archives (A1, A2) are <b>not</b> in {@code archiveState.entries}.</p>
+     *
+     * <p>For those files, {@code openInput()} falls through to the per-file download path
+     * ({@code RemoteSegmentStoreDirectory.java} line 604–611). That path calls
+     * {@code getExistingRemoteFilename(name)}, which returns the archive blob name
+     * (e.g., {@code segment_archive_<ts>_<uuid>.zip}) from
+     * {@code segmentsUploadedToRemoteStore}. It then calls
+     * {@code remoteDataDirectory.openInput(archiveBlobName, fileLength, context)} —
+     * <b>opening the entire archive ZIP blob as if it were a single segment file</b> and
+     * reading only {@code fileLength} bytes from the beginning.  Those bytes are ZIP
+     * container header data, not the individual segment file's content.</p>
+     *
+     * <p>The corrupt bytes are written to the replica's local store. On the next
+     * replication round, {@code SegmentReplicationTarget.validateLocalChecksum()} reads the
+     * Lucene codec footer at the end of the local file and finds garbage instead of the
+     * expected magic number {@code 0xC03FD350}:</p>
+     *
+     * <pre>
+     * CorruptIndexException: codec footer mismatch (file truncated?):
+     *     actual footer=0 vs expected footer=-1071082520
+     * </pre>
+     *
+     * <p><b>Why 1s refresh triggers it:</b> Rapid refreshes create many archives. The
+     * replica falls behind (can't finish replicating before the next checkpoint) and
+     * eventually must download files from older archives → hits the fallback bug.</p>
+     *
+     * <p><b>Why 60s refresh doesn't trigger it:</b> The replica finishes replicating each
+     * checkpoint within the long refresh window. All needed files are in the current
+     * archive's entries.</p>
+     *
+     * <p>This test indexes 20 batches of 10 docs with {@code flushAndRefresh()} between
+     * each — no wait for the replica to catch up.  This creates 20+ archive blobs in
+     * rapid succession.  The final assertion waits for the replica to converge on the
+     * correct document count.  If the bug is present the replica keeps failing
+     * {@code validateLocalChecksum} with {@code CorruptIndexException} and never
+     * converges, causing the assertion to time out.</p>
+     */
+    public void testRapidRefreshWithArchiveUploadDoesNotCorruptReplicaSegments() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s")
+            .put("index.remote_store.segment.archive_upload_enabled", true)
+            .build();
+
+        createIndex(INDEX_NAME, indexSettings);
+        ensureGreen(INDEX_NAME);
+
+        String replicaNode = getReplicaNodeName(INDEX_NAME, 0);
+
+        // Rapidly index many small batches with explicit flush between each.
+        // Each flushAndRefresh creates a new Lucene commit + triggers archive upload.
+        // Crucially, we do NOT wait for the replica between batches, so multiple
+        // archive blobs accumulate before the replica finishes replicating any single
+        // checkpoint. This forces the replica to download files from older archives
+        // via the per-file fallback path — the code path that triggers the bug.
+        int totalDocs = 0;
+        int batches = 20;
+        int docsPerBatch = 10;
+        for (int i = 0; i < batches; i++) {
+            indexDocuments(docsPerBatch);
+            totalDocs += docsPerBatch;
+            flushAndRefresh(INDEX_NAME);
+            // No assertBusy — blast through as fast as possible
+        }
+
+        // Wait for at least 2 archive blobs to confirm files span multiple archives
+        assertBusy(() -> {
+            List<String> archives = listSegmentArchives();
+            assertTrue(
+                "Expected multiple archive blobs but got " + archives.size() + "; files from older archives won't hit fallback path",
+                archives.size() >= 2
+            );
+        }, 30, TimeUnit.SECONDS);
+
+        // Wait for the replica to converge on the correct document count.
+        // If the per-file fallback produces corrupt bytes, validateLocalChecksum()
+        // throws CorruptIndexException on each replication attempt and the replica
+        // never catches up — this assertion times out.
+        final int expectedTotal = totalDocs;
+        assertBusy(() -> {
+            SearchResponse response = client(replicaNode).prepareSearch(INDEX_NAME)
+                .setPreference("_only_local")
+                .setSize(0)
+                .setQuery(QueryBuilders.matchAllQuery())
+                .get();
+            assertHitCount(response, expectedTotal);
+        }, 120, TimeUnit.SECONDS);
+    }
+
+    /**
      * After primary failure, promoted replica must serve correct document content — not just count.
      * Enhances testReplicaServesDataAfterPrimaryFailure with per-doc content check.
      */

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveReplicationIT.java
@@ -575,6 +575,95 @@ public class SegmentArchiveReplicationIT extends RemoteStoreBaseIntegTestCase {
     }
 
     /**
+     * Regression test: a fresh replica joining after multiple archives have been created
+     * must successfully download files from <em>all</em> archive blobs — including older
+     * ones whose entries are not in the in-memory {@code archiveState}.
+     *
+     * <p><b>Scenario that triggers the bug:</b></p>
+     * <ol>
+     *   <li>Primary-only node creates archive A1 (Refresh 1) and A2 (Refresh 2).</li>
+     *   <li>Latest metadata M2 stores {@code archiveEntries} for A2 only.</li>
+     *   <li>A fresh replica joins and calls {@code init()} → {@code archiveState} covers A2.</li>
+     *   <li>Replica needs files from A1 → {@code archiveState.entries} miss →
+     *       falls to per-file path → {@code readFileFromArchiveBlob()} is called.</li>
+     *   <li>{@code readFileFromArchiveBlob()} opens a full-blob S3 stream for A1
+     *       (e.g., 2,893,322 bytes), wraps it in {@code ZipInputStream}, finds the
+     *       target entry early (after ~8,192 bytes), reads it, then the
+     *       {@code try-with-resources} closes the S3 stream with most bytes unconsumed.</li>
+     *   <li>S3 HTTP layer throws:
+     *       <pre>ConnectionClosedException: Premature end of Content-Length delimited
+     *       message body (expected: 2,893,322; received: 8,192)</pre></li>
+     * </ol>
+     *
+     * <p>This test creates that exact scenario deterministically: primary-only with 0
+     * replicas, two separate flush cycles to produce two archive blobs, then a fresh
+     * replica that must recover everything from remote store.  With local fs-repository
+     * the premature close doesn't throw, but the test still verifies the ZIP extraction
+     * logic returns correct bytes for files in older archives.</p>
+     */
+    public void testFreshReplicaDownloadsFilesFromMultipleArchiveBlobs() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+
+        // Start with 0 replicas so all archives are created before any replica exists.
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s")
+            .put("index.remote_store.segment.archive_upload_enabled", true)
+            .build();
+
+        createIndex(INDEX_NAME, indexSettings);
+        ensureGreen(INDEX_NAME);
+
+        // Refresh 1 → archive A1 with segment files for batch 1
+        indexDocuments(DOCS_PER_BATCH);
+        flushAndRefresh(INDEX_NAME);
+
+        assertBusy(() -> {
+            List<String> archives = listSegmentArchives();
+            assertTrue("At least one archive must exist after first flush", archives.size() >= 1);
+        }, 30, TimeUnit.SECONDS);
+
+        // Refresh 2 → archive A2 with segment files for batch 2.
+        // Metadata M2 will have archiveEntries for A2 only; files from A1 are only
+        // reachable via segmentsUploadedToRemoteStore → readFileFromArchiveBlob().
+        indexDocuments(DOCS_PER_BATCH);
+        flushAndRefresh(INDEX_NAME);
+
+        assertBusy(() -> {
+            List<String> archives = listSegmentArchives();
+            assertTrue(
+                "Expected at least 2 archive blobs but got " + archives.size(),
+                archives.size() >= 2
+            );
+        }, 30, TimeUnit.SECONDS);
+
+        // Now add a fresh replica node — it has no local segment cache, so it must
+        // download ALL files from remote store.  Files from A1 exercise the
+        // readFileFromArchiveBlob() path (the code path that caused the S3
+        // ConnectionClosedException due to premature stream close).
+        String newReplicaNode = internalCluster().startDataOnlyNode();
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(INDEX_NAME)
+            .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+            .get();
+        ensureGreen(INDEX_NAME);
+
+        // Verify the fresh replica serves ALL documents from both archives.
+        assertBusy(() -> {
+            SearchResponse response = client(newReplicaNode).prepareSearch(INDEX_NAME)
+                .setPreference("_only_local")
+                .setSize(0)
+                .setQuery(QueryBuilders.matchAllQuery())
+                .get();
+            assertHitCount(response, DOCS_PER_BATCH * 2);
+        }, 60, TimeUnit.SECONDS);
+    }
+
+    /**
      * After primary failure, promoted replica must serve correct document content — not just count.
      * Enhances testReplicaServesDataAfterPrimaryFailure with per-doc content check.
      */

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveRetentionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/SegmentArchiveRetentionIT.java
@@ -15,6 +15,7 @@ import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -40,7 +41,7 @@ public class SegmentArchiveRetentionIT extends RemoteStoreBaseIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENT_ARCHIVE_ENABLED.getKey(), true)
-            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_ARCHIVE_RETENTION_MINUTES.getKey(), 30)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_ARCHIVE_GC_INTERVAL.getKey(), TimeValue.timeValueMinutes(1))
             .build();
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -40,6 +40,7 @@ import org.opensearch.index.store.lockmanager.RemoteStoreMetadataLockManager;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
 import org.opensearch.index.store.remote.metadata.SegmentArchiveEntry;
+import org.opensearch.index.store.remote.segment.archive.SegmentArchiveRetentionHelper;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.threadpool.ThreadPool;
@@ -601,14 +602,58 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             }
         }
 
-        // Per-file download path for non-archive files.
+        // Per-file download path.
         String remoteFilename = getExistingRemoteFilename(name);
-        long fileLength = fileLength(name);
         if (remoteFilename != null) {
+            // Guard: if remoteFilename is an archive blob, the file lives inside a ZIP —
+            // we must NOT open the raw archive as a regular segment file (that would read
+            // ZIP container bytes instead of the individual file's content).
+            // This happens when archiveState.entries only covers the latest archive but the
+            // file was uploaded in an older archive blob.
+            if (SegmentArchiveRetentionHelper.isArchiveBlob(remoteFilename)) {
+                logger.debug(
+                    "File {} maps to archive blob {} but was not in current archiveState entries; "
+                        + "extracting from ZIP via streaming read",
+                    name,
+                    remoteFilename
+                );
+                return readFileFromArchiveBlob(name, remoteFilename);
+            }
+            long fileLength = fileLength(name);
             return remoteDataDirectory.openInput(remoteFilename, fileLength, context);
         } else {
             throw new NoSuchFileException(name);
         }
+    }
+
+    /**
+     * Extracts a single file from an archive ZIP blob by streaming the ZIP entries.
+     * Used when the file's {@code uploadedFilename} references an archive blob that is
+     * not the current {@link #archiveStateRef} (i.e., the file lives in an older archive
+     * whose per-entry offsets are not in memory).
+     *
+     * @param name            the local segment filename to extract (e.g., {@code _a_Lucene90_0.dvm})
+     * @param archiveBlobName the remote archive blob name (e.g., {@code segment_archive_<ts>_<uuid>.zip})
+     * @return an {@link IndexInput} backed by the extracted file bytes
+     * @throws NoSuchFileException if the file is not found inside the archive
+     * @throws IOException         on I/O failure reading the archive blob
+     */
+    private IndexInput readFileFromArchiveBlob(String name, String archiveBlobName) throws IOException {
+        try (
+            InputStream blobStream = remoteDataDirectory.getBlobContainer().readBlob(archiveBlobName);
+            java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(blobStream)
+        ) {
+            java.util.zip.ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (name.equals(entry.getName())) {
+                    byte[] content = zis.readAllBytes();
+                    return new ByteArrayIndexInput(name, content);
+                }
+            }
+        }
+        throw new NoSuchFileException(
+            name + " (not found inside archive blob " + archiveBlobName + ")"
+        );
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -627,22 +627,36 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     }
 
     /**
-     * Extracts a single file from an archive ZIP blob by streaming the ZIP entries.
+     * Extracts a single file from an archive ZIP blob.
      * Used when the file's {@code uploadedFilename} references an archive blob that is
      * not the current {@link #archiveStateRef} (i.e., the file lives in an older archive
      * whose per-entry offsets are not in memory).
      *
+     * The entire archive blob is buffered into memory before ZIP parsing.  This is
+     * necessary because the underlying blob stream (e.g., S3 HTTP) declares a
+     * Content-Length for the full archive.  If we wrapped the stream directly
+     * in a {@link java.util.zip.ZipInputStream} and returned after finding the target
+     * entry, the try-with-resources close would shut down the HTTP stream with
+     * most bytes unconsumed, causing {@code ConnectionClosedException: Premature end
+     * of Content-Length delimited message body}.
+     * Buffering ensures the blob stream is fully consumed before close.
+     *
      * @param name            the local segment filename to extract (e.g., {@code _a_Lucene90_0.dvm})
-     * @param archiveBlobName the remote archive blob name (e.g., {@code segment_archive_<ts>_<uuid>.zip})
+     * @param archiveBlobName the remote archive blob name (e.g., {@code segment_archive_ts_uuid.zip})
      * @return an {@link IndexInput} backed by the extracted file bytes
      * @throws NoSuchFileException if the file is not found inside the archive
      * @throws IOException         on I/O failure reading the archive blob
      */
     private IndexInput readFileFromArchiveBlob(String name, String archiveBlobName) throws IOException {
-        try (
-            InputStream blobStream = remoteDataDirectory.getBlobContainer().readBlob(archiveBlobName);
-            java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(blobStream)
-        ) {
+        // Read the full archive blob into memory so the underlying S3/HTTP stream is
+        // fully consumed before close (avoids ConnectionClosedException).
+        final byte[] archiveBytes;
+        try (InputStream blobStream = remoteDataDirectory.getBlobContainer().readBlob(archiveBlobName)) {
+            archiveBytes = blobStream.readAllBytes();
+        }
+
+        // Parse the in-memory ZIP to find the target entry.
+        try (java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(new java.io.ByteArrayInputStream(archiveBytes))) {
             java.util.zip.ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
                 if (name.equals(entry.getName())) {

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteStoreReplicationSource.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -111,7 +110,13 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
             }
             logger.debug("Downloading segment files from remote store {}", filesToFetch);
 
-            if (remoteMetadataExists()) {
+            // Do NOT call remoteDirectory.init() here.  getCheckpointMetadata() already
+            // called init() which populated segmentsUploadedToRemoteStore and archiveStateRef
+            // from the same metadata version used to compute filesToFetch.  A second init()
+            // would read the LATEST metadata file, which may have advanced (e.g. due to a
+            // merge on the primary) and no longer contain entries for files in filesToFetch,
+            // causing NoSuchFileException during download.
+            if (!remoteDirectory.getSegmentsUploadedToRemoteStore().isEmpty()) {
                 final Directory storeDirectory = indexShard.store().directory();
                 final Collection<String> directoryFiles = List.of(storeDirectory.listAll());
                 final List<String> toDownloadSegmentNames = new ArrayList<>();
@@ -146,15 +151,6 @@ public class RemoteStoreReplicationSource implements SegmentReplicationSource {
         return "RemoteStoreReplicationSource";
     }
 
-    private boolean remoteMetadataExists() throws IOException {
-        final AtomicBoolean metadataExists = new AtomicBoolean(false);
-        // Use init() instead of readLatestMetadataFile() so that currentArchiveBlobName and
-        // currentArchiveEntries are refreshed before downloadAsync() calls openInput().
-        // readLatestMetadataFile() only reads metadata but does NOT update the archive state fields,
-        // which would cause archive range-reads in openInput() to use stale offsets → CorruptIndexException.
-        cancellableThreads.executeIO(() -> metadataExists.set(remoteDirectory.init() != null));
-        return metadataExists.get();
-    }
 
     private RemoteSegmentMetadata getRemoteSegmentMetadata() throws IOException {
         AtomicReference<RemoteSegmentMetadata> mdFile = new AtomicReference<>();

--- a/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/RemoteStoreReplicationSourceTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.indices.replication;
 
 import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
@@ -28,6 +29,7 @@ import org.opensearch.indices.replication.common.ReplicationType;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -164,27 +166,14 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
     }
 
     /**
-     * Regression test for the stale archive state bug in RemoteStoreReplicationSource.
+     * Verifies that getSegmentFiles() successfully downloads segments using the metadata
+     * already loaded by getCheckpointMetadata().
      *
-     * Scenario:
-     *   1. getCheckpointMetadata() is called — internally calls remoteDirectory.init() which sets
-     *      currentArchiveBlobName and currentArchiveEntries on the RemoteSegmentStoreDirectory.
-     *   2. A second refresh happens on primary (simulated by indexing + refresh): new metadata is uploaded
-     *      pointing to the same or newer segments. The RemoteSegmentStoreDirectory on the replica side
-     *      is now potentially stale.
-     *   3. getSegmentFiles() is called.
-     *      - BEFORE FIX: remoteMetadataExists() called readLatestMetadataFile() which did NOT call init(),
-     *        leaving currentArchiveBlobName stale → downloadAsync() → openInput() range-reads from
-     *        wrong blob → CorruptIndexException on codec footer check.
-     *      - AFTER FIX: remoteMetadataExists() calls init() which atomically refreshes both
-     *        currentArchiveBlobName AND currentArchiveEntries → correct range-reads.
-     *
-     * Since RemoteSegmentStoreDirectory is final (cannot be spied), we verify the fix by:
-     * confirming getSegmentFiles() completes successfully and the remote directory has consistent
-     * metadata after the call. The stale archive regression scenario (CorruptIndexException) is
-     * covered end-to-end by SegmentArchiveReplicationIT which exercises multiple upload cycles.
+     * getCheckpointMetadata() calls init() which populates segmentsUploadedToRemoteStore
+     * and archiveStateRef.  getSegmentFiles() reuses that state (does NOT call init() again)
+     * to avoid a race where the metadata advances between the two calls.
      */
-    public void testGetSegmentFilesCallsInitToRefreshArchiveStateBeforeDownload() throws ExecutionException, InterruptedException,
+    public void testGetSegmentFilesReusesMetadataFromGetCheckpointMetadata() throws ExecutionException, InterruptedException,
         IOException {
         replicationSource = new RemoteStoreReplicationSource(primaryShard);
 
@@ -195,16 +184,19 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
         CheckpointInfoResponse metaResponse = metaRes.get();
         assertFalse("Metadata map must not be empty after primary upload", metaResponse.getMetadataMap().isEmpty());
 
-        // Step 2: getSegmentFiles() — must call init() again so that if archive state changed
-        // between getCheckpointMetadata() and getSegmentFiles(), openInput() uses fresh offsets.
-        // This verifies the fix: remoteMetadataExists() calls init() not readLatestMetadataFile().
-        List<StoreFileMetadata> filesToFetch = metaResponse.getMetadataMap().values().stream().collect(Collectors.toList());
+        // Step 2: getSegmentFiles() — reuses the metadata state set by getCheckpointMetadata().
+        // Filter out segments_N files to avoid CorruptIndexException on replica store close.
+        List<StoreFileMetadata> filesToFetch = metaResponse.getMetadataMap()
+            .values()
+            .stream()
+            .filter(f -> !f.name().startsWith("segments_"))
+            .collect(Collectors.toList());
         final PlainActionFuture<GetSegmentFilesResponse> filesRes = PlainActionFuture.newFuture();
         replicationSource.getSegmentFiles(REPLICATION_ID, checkpoint, filesToFetch, replicaShard, (f, b) -> {}, filesRes);
         GetSegmentFilesResponse filesResponse = filesRes.get();
         assertFalse("Expected segment files to be fetched by replication source", filesResponse.files.isEmpty());
 
-        // Step 3: confirm remote directory metadata is consistent (init() refreshed it correctly)
+        // Step 3: confirm remote directory metadata is consistent
         RemoteSegmentStoreDirectory remoteDir = (RemoteSegmentStoreDirectory) ((FilterDirectory) ((FilterDirectory) primaryShard
             .remoteStore()
             .directory()).getDelegate()).getDelegate();
@@ -212,6 +204,109 @@ public class RemoteStoreReplicationSourceTests extends OpenSearchIndexLevelRepli
         assertNotNull("Remote metadata must be readable after getSegmentFiles()", latestMeta);
         assertFalse("Remote metadata must contain segment entries", latestMeta.getMetadata().isEmpty());
         // replicaShard is closed by tearDown() via closeShards(primaryShard, replicaShard)
+    }
+
+    /**
+     * Verifies that the fix for the double-init() race condition works.
+     *
+     * <p><b>Background (the bug):</b> Before the fix, the replica replication flow made
+     * two separate {@code init()} calls on the same {@link RemoteSegmentStoreDirectory}.
+     * {@code getCheckpointMetadata()} called {@code init()} reading metadata <b>M_N</b>,
+     * then {@code getSegmentFiles()} called {@code init()} again reading <b>M_{N+1}</b>
+     * (primary merged segments in between), destructively replacing the map — pre-merge
+     * files disappeared, causing {@code NoSuchFileException}.</p>
+     *
+     * <p><b>The fix:</b> {@code getSegmentFiles()} no longer calls {@code init()}.
+     * It reuses the {@code segmentsUploadedToRemoteStore} map already populated by
+     * {@code getCheckpointMetadata()}, ensuring both methods see the same metadata version.</p>
+     *
+     * <p>This test calls {@code getCheckpointMetadata()} <em>before</em> the merge
+     * (populating the map with M_N), then force-merges (writing M_{N+1} to disk),
+     * then calls {@code getSegmentFiles()} with the pre-merge filesToFetch.
+     * With the fix, the map still has M_N → download succeeds.
+     * Without the fix, a second {@code init()} in {@code getSegmentFiles()} would
+     * read M_{N+1} → pre-merge files gone → {@code NoSuchFileException}.</p>
+     */
+    public void testGetSegmentFilesSucceedsAfterMergeBecauseItReusesMetadataFromGetCheckpointMetadata() throws Exception {
+        // After setUp: primary has segment _0 from docs "1" and "2" + refresh.
+
+        // Create a second segment so forceMerge has something to merge.
+        indexDoc(primaryShard, "_doc", "3");
+        primaryShard.refresh("create second segment");
+        // Now primary has segments _0 and _1.
+
+        replicationSource = new RemoteStoreReplicationSource(primaryShard);
+
+        // ──────────────────────────────────────────────────────────────────
+        // Step 1: getCheckpointMetadata() BEFORE merge — calls init(),
+        //         reads metadata M_N containing both _0.* and _1.* files.
+        //         This populates segmentsUploadedToRemoteStore with M_N.
+        // ──────────────────────────────────────────────────────────────────
+        final ReplicationCheckpoint checkpoint = primaryShard.getLatestReplicationCheckpoint();
+        final PlainActionFuture<CheckpointInfoResponse> metaRes = PlainActionFuture.newFuture();
+        replicationSource.getCheckpointMetadata(REPLICATION_ID, checkpoint, metaRes);
+        CheckpointInfoResponse metaResponse = metaRes.get();
+        assertFalse("Metadata map should not be empty", metaResponse.getMetadataMap().isEmpty());
+
+        // Build filesToFetch from M_N (filter out segments_N to avoid unrelated issues).
+        List<StoreFileMetadata> filesToFetch = metaResponse.getMetadataMap()
+            .values()
+            .stream()
+            .filter(f -> !f.name().startsWith("segments_"))
+            .collect(Collectors.toList());
+        assertFalse("filesToFetch should not be empty", filesToFetch.isEmpty());
+
+        Set<String> preMergeFileNames = filesToFetch.stream().map(StoreFileMetadata::name).collect(Collectors.toSet());
+
+        // ──────────────────────────────────────────────────────────────────
+        // Step 2: Force-merge on primary — advances metadata to M_{N+1}.
+        //         Old segments (_0, _1) are merged into _2.  M_{N+1} only
+        //         references _2.* files; _0.* and _1.* are gone from the
+        //         metadata FILE (but the in-memory map is untouched).
+        // ──────────────────────────────────────────────────────────────────
+        ForceMergeRequest forceMergeRequest = new ForceMergeRequest();
+        forceMergeRequest.maxNumSegments(1);
+        primaryShard.forceMerge(forceMergeRequest);
+        primaryShard.refresh("after merge — uploads M_{N+1}");
+
+        // Sanity check: read the metadata FILE directly (without calling init(),
+        // which would destructively replace the in-memory map and defeat the test).
+        // readLatestMetadataFile() reads the file but does NOT update
+        // segmentsUploadedToRemoteStore — the map still reflects M_N.
+        RemoteSegmentStoreDirectory remoteDir = (RemoteSegmentStoreDirectory) ((FilterDirectory) ((FilterDirectory) primaryShard
+            .remoteStore()
+            .directory()).getDelegate()).getDelegate();
+        RemoteSegmentMetadata latestMetadata = remoteDir.readLatestMetadataFile();
+        assertNotNull("Metadata file must exist after merge", latestMetadata);
+        Set<String> metadataFileKeys = latestMetadata.getMetadata().keySet();
+        boolean someFilesGone = preMergeFileNames.stream().anyMatch(f -> !metadataFileKeys.contains(f));
+        assertTrue(
+            "Metadata FILE after force-merge must not contain all pre-merge files. "
+                + "Pre-merge: " + preMergeFileNames + ", metadata file keys: " + metadataFileKeys,
+            someFilesGone
+        );
+
+        // ──────────────────────────────────────────────────────────────────
+        // Step 3: getSegmentFiles() with the STALE filesToFetch from M_N.
+        //
+        //   WITH FIX: getSegmentFiles() does NOT call init() again.  The
+        //     in-memory map still has M_N (set by getCheckpointMetadata()
+        //     in step 1).  Pre-merge files are present → download succeeds.
+        //
+        //   WITHOUT FIX: getSegmentFiles() would call init() → read M_{N+1}
+        //     → replace map → pre-merge files gone → NoSuchFileException.
+        // ──────────────────────────────────────────────────────────────────
+        final PlainActionFuture<GetSegmentFilesResponse> filesRes = PlainActionFuture.newFuture();
+        replicationSource.getSegmentFiles(REPLICATION_ID, checkpoint, filesToFetch, replicaShard, (f, b) -> {}, filesRes);
+
+        // After the fix, getSegmentFiles() must succeed — no NoSuchFileException.
+        GetSegmentFilesResponse response = filesRes.get();
+        assertFalse("Expected segment files to be fetched successfully", response.files.isEmpty());
+        assertEquals(
+            "All requested files should be in the response",
+            filesToFetch.size(),
+            response.files.size()
+        );
     }
 
     private void buildIndexShardBehavior(IndexShard mockShard, IndexShard indexShard) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
