### PR TITLE
Remove duplicate wait time on translog archive batch

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinator.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinator.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.translog.transfer.TransferService;
 import org.opensearch.index.translog.transfer.TranslogArchivePathHelper;
@@ -87,12 +86,10 @@ public class TranslogArchiveBatchCoordinator {
     private final String nodeId;
     private final BlobPath archiveBasePath;
     private final RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm;
-    private final TimeValue batchInterval;
     private final long uploadTimeoutMillis;
 
     // Current batch state — guarded by lock
     private final ReentrantLock lock = new ReentrantLock();
-    private final Condition batchReady = lock.newCondition();
     private final Condition batchComplete = lock.newCondition();
 
     /** Accumulated shard data for current batch. */
@@ -103,10 +100,10 @@ public class TranslogArchiveBatchCoordinator {
     private volatile CountDownLatch dispatchLatch;
     /** Error from the most recent dispatch, if any. */
     private volatile IOException dispatchError;
-    /** Timestamp when the first shard submitted to this batch. */
-    private long batchStartNanos;
-    /** Whether a dispatch is currently in progress. */
+    /** Whether a dispatch is currently in progress — stays true until upload thread finishes. */
     private boolean dispatching;
+    /** Latch for the NEXT batch (accumulated while current upload runs). */
+    private volatile CountDownLatch nextDispatchLatch;
 
     /**
      * Data submitted by one shard for inclusion in the batch ZIP.
@@ -158,22 +155,33 @@ public class TranslogArchiveBatchCoordinator {
         String indexUUID,
         String nodeId,
         BlobPath archiveBasePath,
-        RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm,
-        TimeValue batchInterval
+        RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm
     ) {
         this.indexUUID = indexUUID;
         this.nodeId = nodeId;
         this.archiveBasePath = archiveBasePath;
         this.pathHashAlgorithm = pathHashAlgorithm;
-        this.batchInterval = batchInterval;
-        this.uploadTimeoutMillis = Math.max(batchInterval.millis() * 10, 30_000);
+        this.uploadTimeoutMillis = 30_000;
         this.dispatchLatch = new CountDownLatch(1);
-        this.batchStartNanos = 0;
+        this.nextDispatchLatch = null;
     }
 
     /**
      * Submit shard data to the current batch and block until the batch ZIP is uploaded.
      * Called by the shard's sync thread. Returns only after the ZIP is durably persisted in remote store.
+     * <p>
+     * <b>No batch interval wait here.</b> The upstream {@code BufferedAsyncIOProcessor} in
+     * {@code IndexShard.translogSyncProcessor} already buffers sync requests for the configured
+     * {@code cluster.remote_store.translog.buffer_interval} (default 650ms). By the time
+     * {@code Engine.ensureTranslogSynced()} calls {@code RemoteFsTranslog.upload()} →
+     * {@code submitAndWait()} for each shard sequentially, all shard sync requests from the same
+     * buffer interval drain are executed back-to-back. Adding a second wait here would
+     * double the latency on the indexing critical path (with {@code durability=request}).
+     * <p>
+     * Instead, this method uses a two-phase dispatch: if no upload is in progress, it dispatches
+     * immediately. If an upload IS in progress, the shard's data is queued for the NEXT batch,
+     * which is dispatched automatically when the current upload finishes. This allows back-to-back
+     * submissions (from the upstream drain) to be batched without any artificial wait.
      *
      * @param shardData the shard's translog data for this batch
      * @param transferService the transfer service to use for upload
@@ -188,33 +196,18 @@ public class TranslogArchiveBatchCoordinator {
             pendingShards.put(shardData.getShardId(), shardData);
             long shardBytes = shardData.getEntries().stream().mapToLong(ArchiveBuilder.ArchiveBuildEntry::getSize).sum();
             pendingBatchBytes += shardBytes;
-            if (batchStartNanos == 0) {
-                batchStartNanos = System.nanoTime();
-            }
-            myLatch = dispatchLatch;
 
-            // If batch size limit reached, dispatch immediately without waiting for interval.
-            if (pendingBatchBytes >= MAX_BATCH_BYTES) {
-                logger.debug("Batch size limit reached ({} bytes), dispatching early for index {}", pendingBatchBytes, indexUUID);
-                if (!dispatching) {
-                    dispatchUnderLock(transferService);
-                }
+            if (!dispatching) {
+                // No upload in progress — dispatch immediately.
+                myLatch = dispatchLatch;
+                dispatchUnderLock(transferService);
             } else {
-                // Wait for remaining batch interval, then dispatch
-                long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - batchStartNanos);
-                long remainingMs = batchInterval.millis() - elapsedMs;
-                if (remainingMs > 0) {
-                    try {
-                        batchReady.await(remainingMs, TimeUnit.MILLISECONDS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new IOException("Interrupted while waiting for batch interval", e);
-                    }
+                // Upload in progress — this shard will be included in the NEXT batch.
+                // Create a next-batch latch if not already created.
+                if (nextDispatchLatch == null) {
+                    nextDispatchLatch = new CountDownLatch(1);
                 }
-                // After waiting, if no one else dispatched yet, this thread dispatches
-                if (!dispatching && !pendingShards.isEmpty()) {
-                    dispatchUnderLock(transferService);
-                }
+                myLatch = nextDispatchLatch;
             }
         } finally {
             lock.unlock();
@@ -256,29 +249,22 @@ public class TranslogArchiveBatchCoordinator {
     }
 
     /**
-     * Must be called under lock. Hands the current batch off to a background upload thread and
-     * resets the coordinator state immediately so that the next batch can start accumulating
-     * without waiting for the upload to complete (pipelining).
-     * <p>
-     * Callers still wait for the upload to finish via {@code dispatchLatch.await()} in
-     * {@link #submitAndWait}, preserving {@code durability=REQUEST} correctness.
+     * Must be called under lock. Hands the current batch off to a background upload thread.
+     * {@code dispatching} stays {@code true} while the upload runs, so subsequent submissions
+     * accumulate in {@code pendingShards} for the next batch. When the upload finishes, the
+     * upload thread re-acquires the lock and dispatches any accumulated pending shards.
      */
     private void dispatchUnderLock(TransferService transferService) {
         dispatching = true;
         Map<Integer, ShardArchiveData> batch = new HashMap<>(pendingShards);
         CountDownLatch currentLatch = dispatchLatch;
 
-        // Reset state for next batch immediately — callers can start accumulating while upload runs
+        // Clear pending state for next batch accumulation while upload runs
         pendingShards.clear();
         pendingBatchBytes = 0;
-        batchStartNanos = 0;
         dispatchError = null;
-        dispatchLatch = new CountDownLatch(1);
-        dispatching = false;
-        batchComplete.signalAll();
 
         // Hand off upload to a background thread — lock is NOT held during upload.
-        // dispatchError is set BEFORE countDown so submitAndWait() sees it after latch.await().
         Thread uploadThread = new Thread(() -> {
             IOException uploadException = null;
             try {
@@ -290,6 +276,33 @@ public class TranslogArchiveBatchCoordinator {
                 // Set error before releasing latch so submitAndWait() sees it after await()
                 dispatchError = uploadException;
                 currentLatch.countDown();
+
+                // Check if more shards accumulated while we were uploading
+                lock.lock();
+                try {
+                    dispatching = false;
+                    if (!pendingShards.isEmpty()) {
+                        // Promote nextDispatchLatch to dispatchLatch and dispatch
+                        if (nextDispatchLatch != null) {
+                            dispatchLatch = nextDispatchLatch;
+                            nextDispatchLatch = null;
+                        } else {
+                            dispatchLatch = new CountDownLatch(1);
+                        }
+                        dispatchUnderLock(transferService);
+                    } else {
+                        // No pending shards — reset for next submission
+                        if (nextDispatchLatch != null) {
+                            dispatchLatch = nextDispatchLatch;
+                            nextDispatchLatch = null;
+                        } else {
+                            dispatchLatch = new CountDownLatch(1);
+                        }
+                        batchComplete.signalAll();
+                    }
+                } finally {
+                    lock.unlock();
+                }
             }
         }, "translog-archive-upload-" + indexUUID);
         uploadThread.setDaemon(true);

--- a/server/src/main/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinator.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinator.java
@@ -231,24 +231,6 @@ public class TranslogArchiveBatchCoordinator {
     }
 
     /**
-     * Force-dispatch the current batch even if the interval hasn't elapsed.
-     * Called by a scheduled timer to ensure batches don't wait forever.
-     *
-     * @param transferService the transfer service for upload
-     */
-    public void timerDispatch(TransferService transferService) {
-        lock.lock();
-        try {
-            if (pendingShards.isEmpty() || dispatching) {
-                return;
-            }
-            dispatchUnderLock(transferService);
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    /**
      * Must be called under lock. Hands the current batch off to a background upload thread.
      * {@code dispatching} stays {@code true} while the upload runs, so subsequent submissions
      * accumulate in {@code pendingShards} for the next batch. When the upload finishes, the
@@ -282,22 +264,16 @@ public class TranslogArchiveBatchCoordinator {
                 try {
                     dispatching = false;
                     if (!pendingShards.isEmpty()) {
-                        // Promote nextDispatchLatch to dispatchLatch and dispatch
-                        if (nextDispatchLatch != null) {
-                            dispatchLatch = nextDispatchLatch;
-                            nextDispatchLatch = null;
-                        } else {
-                            dispatchLatch = new CountDownLatch(1);
-                        }
+                        // Shards accumulated while upload ran — they all hold nextDispatchLatch.
+                        // Promote it to dispatchLatch and dispatch the next batch.
+                        assert nextDispatchLatch != null : "pendingShards non-empty but nextDispatchLatch is null";
+                        dispatchLatch = nextDispatchLatch;
+                        nextDispatchLatch = null;
                         dispatchUnderLock(transferService);
                     } else {
-                        // No pending shards — reset for next submission
-                        if (nextDispatchLatch != null) {
-                            dispatchLatch = nextDispatchLatch;
-                            nextDispatchLatch = null;
-                        } else {
-                            dispatchLatch = new CountDownLatch(1);
-                        }
+                        // No pending work — reset latch for the next submitAndWait() call.
+                        assert nextDispatchLatch == null : "nextDispatchLatch set but pendingShards is empty";
+                        dispatchLatch = new CountDownLatch(1);
                         batchComplete.signalAll();
                     }
                 } finally {

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -944,9 +944,6 @@ public class IndicesService extends AbstractLifecycleComponent
             // Wire archive batch coordinator for indices with archive upload enabled
             if (indexService.getIndexSettings().isTranslogArchiveUploadEnabled()
                 && indexService.getIndexSettings().isRemoteTranslogStoreEnabled()) {
-                TimeValue batchInterval = remoteStoreSettings != null
-                    ? remoteStoreSettings.getClusterRemoteTranslogBufferInterval()
-                    : TimeValue.timeValueMillis(650);
                 org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm hashAlgo = remoteStoreSettings != null
                     ? remoteStoreSettings.getPathHashAlgorithm()
                     : org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1;
@@ -963,8 +960,7 @@ public class IndicesService extends AbstractLifecycleComponent
                     index.getUUID(),
                     localNodeId,
                     new org.opensearch.common.blobstore.BlobPath(),
-                    hashAlgo,
-                    batchInterval
+                    hashAlgo
                 );
                 TranslogArchiveBatchCoordinator.register(coordinator);
                 translogArchiveCollector.registerCoordinatorIndex(index.getUUID());

--- a/server/src/test/java/org/opensearch/common/util/concurrent/BufferedAsyncIOProcessorBatchingTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/BufferedAsyncIOProcessorBatchingTests.java
@@ -1,0 +1,241 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util.concurrent;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Proves that {@link BufferedAsyncIOProcessor} already batches multiple items submitted
+ * within the buffer interval into a single {@code write()} call. This means downstream
+ * consumers (like {@code TranslogArchiveBatchCoordinator}) do NOT need their own batch
+ * interval wait — the upstream processor has already done the buffering.
+ */
+public class BufferedAsyncIOProcessorBatchingTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private ThreadContext threadContext;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("batching-test");
+        threadContext = new ThreadContext(Settings.EMPTY);
+    }
+
+    @After
+    public void cleanup() {
+        terminate(threadPool);
+    }
+
+    /**
+     * Multiple items submitted rapidly within the buffer interval are delivered
+     * together in a single {@code write()} invocation — proving that
+     * BufferedAsyncIOProcessor already provides interval-based batching.
+     *
+     * Simulates the translog sync path: multiple shards of the same index
+     * call {@code IndexShard.sync()} concurrently. The BufferedAsyncIOProcessor
+     * collects all their Translog.Location items and delivers them as one batch
+     * to {@code Engine.ensureTranslogSynced()}, which calls
+     * {@code RemoteFsTranslog.ensureSynced()} for each location.
+     *
+     * This proves that a downstream batch coordinator does NOT need to add its
+     * own wait interval — the items are already temporally co-located.
+     */
+    public void testMultipleItemsWithinIntervalAreBatchedInSingleWrite() throws Exception {
+        final int itemCount = 10;
+        final long bufferIntervalMs = 500;
+
+        // Track how many items each write() call receives
+        ConcurrentLinkedQueue<Integer> batchSizes = new ConcurrentLinkedQueue<>();
+        CountDownLatch allNotified = new CountDownLatch(itemCount);
+
+        BufferedAsyncIOProcessor<Integer> processor = new BufferedAsyncIOProcessor<>(
+            logger,
+            10240,
+            threadContext,
+            threadPool,
+            () -> TimeValue.timeValueMillis(bufferIntervalMs)
+        ) {
+            @Override
+            protected void write(List<Tuple<Integer, Consumer<Exception>>> candidates) throws IOException {
+                batchSizes.add(candidates.size());
+            }
+
+            @Override
+            protected String getBufferProcessThreadPoolName() {
+                return ThreadPool.Names.TRANSLOG_SYNC;
+            }
+        };
+
+        // Submit all items rapidly (well within the buffer interval)
+        for (int i = 0; i < itemCount; i++) {
+            processor.put(i, e -> allNotified.countDown());
+        }
+
+        assertTrue("All items should be processed", allNotified.await(bufferIntervalMs * 3, TimeUnit.MILLISECONDS));
+
+        // The key assertion: the FIRST write() call should contain multiple items
+        // (ideally all of them) because they were all submitted within the buffer interval.
+        int firstBatchSize = batchSizes.peek();
+        assertTrue(
+            "First write() call should batch multiple items (got " + firstBatchSize + " out of " + itemCount + "). "
+                + "This proves BufferedAsyncIOProcessor already buffers items within the interval. "
+                + "Batch sizes: " + batchSizes,
+            firstBatchSize > 1
+        );
+
+        // Total items across all write() calls must equal itemCount
+        int totalProcessed = batchSizes.stream().mapToInt(Integer::intValue).sum();
+        assertEquals("All items must be processed", itemCount, totalProcessed);
+    }
+
+    /**
+     * Concurrent submitters from multiple threads (simulating multiple shard sync threads
+     * for the same index) are batched into a single write() call within one buffer interval.
+     *
+     * This directly models the scenario where 64 concurrent indexing clients drive
+     * shard syncs that all arrive at the BufferedAsyncIOProcessor within 650ms.
+     */
+    public void testConcurrentSubmittersAreBatchedWithinInterval() throws Exception {
+        final int threadCount = 8;
+        final long bufferIntervalMs = 500;
+
+        ConcurrentLinkedQueue<Integer> batchSizes = new ConcurrentLinkedQueue<>();
+        CountDownLatch allNotified = new CountDownLatch(threadCount);
+        CyclicBarrier startBarrier = new CyclicBarrier(threadCount);
+
+        BufferedAsyncIOProcessor<Integer> processor = new BufferedAsyncIOProcessor<>(
+            logger,
+            10240,
+            threadContext,
+            threadPool,
+            () -> TimeValue.timeValueMillis(bufferIntervalMs)
+        ) {
+            @Override
+            protected void write(List<Tuple<Integer, Consumer<Exception>>> candidates) throws IOException {
+                batchSizes.add(candidates.size());
+            }
+
+            @Override
+            protected String getBufferProcessThreadPoolName() {
+                return ThreadPool.Names.TRANSLOG_SYNC;
+            }
+        };
+
+        // All threads submit simultaneously
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            final int shardId = i;
+            Thread t = new Thread(() -> {
+                try {
+                    startBarrier.await(5, TimeUnit.SECONDS);
+                    processor.put(shardId, e -> allNotified.countDown());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, "shard-sync-" + i);
+            t.setDaemon(true);
+            threads.add(t);
+            t.start();
+        }
+
+        assertTrue("All items should be processed", allNotified.await(bufferIntervalMs * 3, TimeUnit.MILLISECONDS));
+
+        for (Thread t : threads) {
+            t.join(5000);
+        }
+
+        // With concurrent submissions all arriving before the first drain, the first
+        // write() should contain most (if not all) items.
+        int maxBatchSize = batchSizes.stream().mapToInt(Integer::intValue).max().orElse(0);
+        assertTrue(
+            "At least one write() call should batch multiple concurrent submitters (max batch size: "
+                + maxBatchSize + ", threads: " + threadCount + "). "
+                + "This proves the upstream BufferedAsyncIOProcessor already batches concurrent shard syncs. "
+                + "Downstream coordinators should NOT add their own wait interval.",
+            maxBatchSize > 1
+        );
+
+        int totalProcessed = batchSizes.stream().mapToInt(Integer::intValue).sum();
+        assertEquals("All items must be processed", threadCount, totalProcessed);
+    }
+
+    /**
+     * Verifies that items submitted AFTER the buffer interval elapses go into the NEXT
+     * write() batch — confirming the interval-based batching boundary.
+     */
+    public void testItemsAfterIntervalGoToNextBatch() throws Exception {
+        final long bufferIntervalMs = 200;
+        final AtomicInteger writeCallCount = new AtomicInteger(0);
+        ConcurrentLinkedQueue<Integer> batchSizes = new ConcurrentLinkedQueue<>();
+        CountDownLatch firstBatchDone = new CountDownLatch(1);
+        CountDownLatch secondBatchDone = new CountDownLatch(1);
+
+        BufferedAsyncIOProcessor<String> processor = new BufferedAsyncIOProcessor<>(
+            logger,
+            10240,
+            threadContext,
+            threadPool,
+            () -> TimeValue.timeValueMillis(bufferIntervalMs)
+        ) {
+            @Override
+            protected void write(List<Tuple<String, Consumer<Exception>>> candidates) throws IOException {
+                batchSizes.add(candidates.size());
+                writeCallCount.incrementAndGet();
+            }
+
+            @Override
+            protected String getBufferProcessThreadPoolName() {
+                return ThreadPool.Names.TRANSLOG_SYNC;
+            }
+        };
+
+        // Submit 3 items in the first interval
+        for (int i = 0; i < 3; i++) {
+            processor.put("batch1-item" + i, e -> firstBatchDone.countDown());
+        }
+
+        // Wait for first batch to process
+        assertTrue("First batch should complete", firstBatchDone.await(bufferIntervalMs * 3, TimeUnit.MILLISECONDS));
+
+        // Wait past the buffer interval
+        Thread.sleep(bufferIntervalMs + 50);
+
+        // Submit 2 more items — these should go into a separate write() call
+        for (int i = 0; i < 2; i++) {
+            processor.put("batch2-item" + i, e -> secondBatchDone.countDown());
+        }
+
+        assertTrue("Second batch should complete", secondBatchDone.await(bufferIntervalMs * 3, TimeUnit.MILLISECONDS));
+
+        // There should be at least 2 write() calls (items split across intervals)
+        assertTrue(
+            "Should have at least 2 write() calls for items across intervals (got " + writeCallCount.get() + ")",
+            writeCallCount.get() >= 2
+        );
+    }
+}
+

--- a/server/src/test/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinatorTests.java
@@ -134,15 +134,6 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
         );
     }
 
-    public void testTimerDispatchWithNoPending() {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
-        TransferService transferService = mock(TransferService.class);
-
-        // Should be a no-op
-        coordinator.timerDispatch(transferService);
-        assertEquals(0, coordinator.getPendingShardCount());
-    }
-
     public void testEmptyEntriesNoUpload() throws Exception {
         TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
@@ -498,7 +489,6 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
 
         // Force dispatch after threads have submitted
         Thread.sleep(60);
-        coordinator.timerDispatch(transferService);
 
         assertTrue("All threads should complete", allDone.await(30, TimeUnit.SECONDS));
         // All threads that were in the same batch should have received the error

--- a/server/src/test/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogArchiveBatchCoordinatorTests.java
@@ -10,7 +10,6 @@ package org.opensearch.index.translog;
 
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.stream.write.WritePriority;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.translog.transfer.TransferService;
 import org.opensearch.index.translog.transfer.TranslogArchivePathHelper;
@@ -38,13 +37,12 @@ import static org.mockito.Mockito.verify;
 
 public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
 
-    private TranslogArchiveBatchCoordinator createCoordinator(TimeValue batchInterval) {
+    private TranslogArchiveBatchCoordinator createCoordinator() {
         return new TranslogArchiveBatchCoordinator(
             "test-index-uuid",
             "test-node-id",
             new BlobPath().add("repo-root"),
-            RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1,
-            batchInterval
+            RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1
         );
     }
 
@@ -58,7 +56,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
     }
 
     public void testSingleShardSubmitAndDispatch() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         TranslogArchiveBatchCoordinator.ShardArchiveData shardData = createShardData(0, "shard0 data");
@@ -78,50 +76,55 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
     }
 
     public void testMultipleShardsSingleZip() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(50));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
-        AtomicInteger uploadCount = new AtomicInteger(0);
+
+        // Slow upload: gives time for shard 1 to arrive while shard 0's upload is in progress.
+        // Shard 1's data accumulates in pendingShards and is dispatched in the NEXT batch
+        // after shard 0's upload finishes.
+        org.mockito.Mockito.doAnswer(inv -> {
+            Thread.sleep(200);
+            return null;
+        }).when(transferService).uploadBlobStream(any(), anyLong(), any(), anyString(), any(), any());
 
         TranslogArchiveBatchCoordinator.ShardArchiveData shard0 = createShardData(0, "shard0 data");
         TranslogArchiveBatchCoordinator.ShardArchiveData shard1 = createShardData(1, "shard1 data");
+        TranslogArchiveBatchCoordinator.ShardArchiveData shard2 = createShardData(2, "shard2 data");
 
-        // Submit shard 0 first (won't dispatch yet — interval not elapsed)
-        // Then use timerDispatch to trigger after both are submitted
-        CountDownLatch bothSubmitted = new CountDownLatch(2);
+        CountDownLatch allDone = new CountDownLatch(3);
         AtomicReference<Exception> error = new AtomicReference<>();
 
+        // Shard 0 submits first — triggers immediate dispatch
         Thread t0 = new Thread(() -> {
             try {
                 coordinator.submitAndWait(shard0, transferService);
-                bothSubmitted.countDown();
-            } catch (Exception e) {
-                error.set(e);
-                bothSubmitted.countDown();
-            }
+            } catch (Exception e) { error.compareAndSet(null, e); } finally { allDone.countDown(); }
         });
 
+        // Shards 1 and 2 submit while shard 0's upload is in progress — they accumulate
+        // and are dispatched together in one ZIP when shard 0's upload finishes.
         Thread t1 = new Thread(() -> {
             try {
+                Thread.sleep(50); // ensure shard 0's dispatch is already running
                 coordinator.submitAndWait(shard1, transferService);
-                bothSubmitted.countDown();
-            } catch (Exception e) {
-                error.set(e);
-                bothSubmitted.countDown();
-            }
+            } catch (Exception e) { error.compareAndSet(null, e); } finally { allDone.countDown(); }
+        });
+        Thread t2 = new Thread(() -> {
+            try {
+                Thread.sleep(80);
+                coordinator.submitAndWait(shard2, transferService);
+            } catch (Exception e) { error.compareAndSet(null, e); } finally { allDone.countDown(); }
         });
 
         t0.start();
         t1.start();
+        t2.start();
 
-        // Wait a bit for both to submit, then trigger dispatch
-        Thread.sleep(60);
-        coordinator.timerDispatch(transferService);
-
-        assertTrue("Both threads should complete", bothSubmitted.await(5, TimeUnit.SECONDS));
+        assertTrue("All threads should complete", allDone.await(10, TimeUnit.SECONDS));
         assertNull("No errors expected", error.get());
 
-        // Only ONE zip upload should have happened (both shards bundled)
-        verify(transferService, times(1)).uploadBlobStream(
+        // Exactly 2 ZIP uploads: batch 1 = shard 0, batch 2 = shard 1 + shard 2 (bundled)
+        verify(transferService, times(2)).uploadBlobStream(
             any(InputStream.class),
             anyLong(),
             any(BlobPath.class),
@@ -132,7 +135,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
     }
 
     public void testTimerDispatchWithNoPending() {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMinutes(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         // Should be a no-op
@@ -141,7 +144,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
     }
 
     public void testEmptyEntriesNoUpload() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         // Empty entries
@@ -167,7 +170,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
     }
 
     public void testUploadPathContainsTranslogData() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         coordinator.submitAndWait(createShardData(0, "test"), transferService);
@@ -201,7 +204,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
 
     public void testUploadPathUsesHashNodeIdNotGenBucket() throws Exception {
         // Regression test: upload path must use hash(nodeId) not a hardcoded bucket like "0".
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         coordinator.submitAndWait(createShardData(0, "hello"), transferService);
@@ -231,7 +234,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * Static registry: register, get, unregister lifecycle.
      */
     public void testStaticRegistryLifecycle() {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMinutes(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         String uuid = coordinator.getIndexUUID();
 
         // Initially not registered
@@ -254,8 +257,8 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * Static registry: registering a second coordinator for the same index replaces the first.
      */
     public void testStaticRegistryReplacesExisting() {
-        TranslogArchiveBatchCoordinator c1 = createCoordinator(TimeValue.timeValueMinutes(1));
-        TranslogArchiveBatchCoordinator c2 = createCoordinator(TimeValue.timeValueMinutes(2));
+        TranslogArchiveBatchCoordinator c1 = createCoordinator();
+        TranslogArchiveBatchCoordinator c2 = createCoordinator();
         String uuid = c1.getIndexUUID();
 
         TranslogArchiveBatchCoordinator.register(c1);
@@ -271,7 +274,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * Upload failure triggers exactly UPLOAD_RETRY_MAX_ATTEMPTS (2) upload attempts before giving up.
      */
     public void testUploadRetryCountIsExactlyTwo() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         org.mockito.Mockito.doThrow(new IOException("simulated failure"))
@@ -309,12 +312,13 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      */
     public void testConcurrentDispatchUnderLoad() throws Exception {
         int numShards = 8;
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(50));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
         AtomicInteger uploadCount = new AtomicInteger(0);
-        // Count uploads (thread-safe)
+        // Slow upload so that concurrent shards accumulate in pendingShards while the first upload runs.
         org.mockito.Mockito.doAnswer(inv -> {
             uploadCount.incrementAndGet();
+            Thread.sleep(100);
             return null;
         })
             .when(transferService)
@@ -340,9 +344,9 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
 
         assertTrue("All threads should complete within timeout", allDone.await(30, TimeUnit.SECONDS));
         assertNull("No errors expected, got: " + firstError.get(), firstError.get());
-        // At least one upload happened, but could be more if batches split across intervals
+        // At least one upload happened, but could be more if batches split
         assertTrue("At least one upload should have happened", uploadCount.get() >= 1);
-        // Should be far fewer uploads than shards (batching works)
+        // With slow upload, most shards should batch — expect significantly fewer uploads than shards
         assertTrue("Uploads (" + uploadCount.get() + ") should be fewer than shards (" + numShards + ")", uploadCount.get() < numShards);
     }
 
@@ -351,7 +355,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * the error wrapped in an IOException.
      */
     public void testCoordinatorUploadFailurePropagates() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(1));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         // Simulate an upload that throws immediately
@@ -398,17 +402,17 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * submissions for batch N+1 — i.e. the collection window for batch N+1 starts as soon
      * as batch N is handed off to the upload thread, NOT after the upload completes.
      *
-     * If upload takes U ms and batch interval is B ms, then two consecutive cycles should
-     * complete in approximately max(B, U) + B, NOT 2*(B + U).
+     * With immediate dispatch (no batch interval), when shard 0 submits, it dispatches
+     * immediately. While that upload is in progress, shard 1 submits and gets queued into
+     * a NEW batch. When shard 0's upload completes, shard 1's batch dispatches.
      *
-     * We verify this by injecting a slow upload (300ms) with a short batch interval (50ms).
-     * Without pipelining: 2 cycles = 2 * (50 + 300) = 700ms minimum.
-     * With pipelining:    2 cycles = (50 + 300) + 50 = 400ms (upload and next collection overlap).
+     * Total time should be approximately 2 * uploadDelay (sequential uploads),
+     * NOT 2 * uploadDelay + blocking (which would happen if shard 1 had to wait
+     * for shard 0's upload before even being accepted).
      */
     public void testNextBatchCollectionStartsWhileUploadInProgress() throws Exception {
-        int batchIntervalMs = 50;
         int uploadDelayMs = 300;
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(batchIntervalMs));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         // Slow upload: blocks for uploadDelayMs
@@ -419,14 +423,11 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
 
         CountDownLatch bothDone = new CountDownLatch(2);
         AtomicReference<Exception> error = new AtomicReference<>();
-        AtomicReference<Long> firstSubmitEndMs = new AtomicReference<>();
-        AtomicReference<Long> secondSubmitEndMs = new AtomicReference<>();
 
-        // Batch 1: submit shard 0, wait for it to complete
+        // Batch 1: submit shard 0 — dispatches immediately, upload takes 300ms
         Thread batch1 = new Thread(() -> {
             try {
                 coordinator.submitAndWait(createShardData(0, "batch1"), transferService);
-                firstSubmitEndMs.set(System.currentTimeMillis());
             } catch (Exception e) {
                 error.set(e);
             } finally {
@@ -434,12 +435,11 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
             }
         }, "batch1-thread");
 
-        // Batch 2: submit shard 1 shortly after batch 1 starts (while upload of batch 1 is in progress)
+        // Batch 2: submit shard 1 while batch 1's upload is in progress
         Thread batch2 = new Thread(() -> {
             try {
-                Thread.sleep(batchIntervalMs + 10); // start after batch 1 has been dispatched
+                Thread.sleep(50); // start after batch 1 has been dispatched
                 coordinator.submitAndWait(createShardData(1, "batch2"), transferService);
-                secondSubmitEndMs.set(System.currentTimeMillis());
             } catch (Exception e) {
                 error.set(e);
             } finally {
@@ -455,22 +455,15 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
         long totalMs = System.currentTimeMillis() - start;
         assertNull("No errors expected: " + error.get(), error.get());
 
-        // With pipelining: batch2 collection starts while batch1 uploads
-        // total ≈ (batchInterval + uploadDelay) + batchInterval = 400ms
-        // Without pipelining: total ≈ (batchInterval + uploadDelay) * 2 = 700ms
-        long pipelinedBound = (batchIntervalMs + uploadDelayMs) + batchIntervalMs + 100; // 400ms + slack
+        // With pipelining: shard 1 is accepted immediately (not blocked by shard 0's upload)
+        // Total ≈ 2 * uploadDelay + small overhead, NOT much more
+        long maxExpected = 2 * uploadDelayMs + 200; // 800ms generous bound
         assertTrue(
-            "With pipelining total time "
-                + totalMs
-                + "ms should be < "
-                + pipelinedBound
-                + "ms (non-pipelined would be ~"
-                + 2 * (batchIntervalMs + uploadDelayMs)
-                + "ms)",
-            totalMs < pipelinedBound
+            "Total time " + totalMs + "ms should be < " + maxExpected + "ms",
+            totalMs < maxExpected
         );
 
-        // Both uploads happened (two separate batches)
+        // Both uploads happened (two separate batches since they arrived at different times)
         verify(transferService, times(2)).uploadBlobStream(any(), anyLong(), any(), anyString(), any(), any());
     }
 
@@ -479,7 +472,7 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
      * all threads that submitted to the same batch receive the error.
      */
     public void testCoordinatorFailurePropagesToMultipleWaitingThreads() throws Exception {
-        TranslogArchiveBatchCoordinator coordinator = createCoordinator(TimeValue.timeValueMillis(50));
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
         TransferService transferService = mock(TransferService.class);
 
         org.mockito.Mockito.doThrow(new IOException("simulated failure"))
@@ -510,5 +503,98 @@ public class TranslogArchiveBatchCoordinatorTests extends OpenSearchTestCase {
         assertTrue("All threads should complete", allDone.await(30, TimeUnit.SECONDS));
         // All threads that were in the same batch should have received the error
         assertTrue("At least one thread should get the error", errorCount.get() >= 1);
+    }
+
+    /**
+     * Proves that with immediate dispatch (no batch interval wait), multiple shards
+     * submitting concurrently — as they would after BufferedAsyncIOProcessor drains
+     * all buffered sync requests — are bundled into a single ZIP upload.
+     *
+     * This simulates the real scenario: BufferedAsyncIOProcessor buffers for 650ms,
+     * then drains all items, calling ensureTranslogSynced() which calls upload() →
+     * submitAndWait() for each shard nearly simultaneously.
+     *
+     * Key assertion: with a slow upload (to keep the dispatch window open), the FIRST
+     * dispatch collects all concurrent submitters into one ZIP. Without immediate dispatch,
+     * each shard would wait for its own interval, resulting in more uploads.
+     */
+    public void testConcurrentShardsAfterUpstreamBufferDrainAreBatchedInOneZip() throws Exception {
+        int numShards = 6;
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
+        TransferService transferService = mock(TransferService.class);
+        AtomicInteger uploadCount = new AtomicInteger(0);
+
+        // Simulate an upload that takes 200ms — while this runs, subsequent shard submissions
+        // accumulate in pendingShards and are dispatched together when the upload finishes.
+        org.mockito.Mockito.doAnswer(inv -> {
+            uploadCount.incrementAndGet();
+            Thread.sleep(200);
+            return null;
+        }).when(transferService).uploadBlobStream(any(), anyLong(), any(), anyString(), any(), any());
+
+        CyclicBarrier barrier = new CyclicBarrier(numShards);
+        CountDownLatch allDone = new CountDownLatch(numShards);
+        AtomicReference<Exception> firstError = new AtomicReference<>();
+        long startMs = System.currentTimeMillis();
+
+        for (int i = 0; i < numShards; i++) {
+            final int shardId = i;
+            new Thread(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    coordinator.submitAndWait(createShardData(shardId, "shard" + shardId), transferService);
+                } catch (Exception e) {
+                    firstError.compareAndSet(null, e);
+                } finally {
+                    allDone.countDown();
+                }
+            }, "shard-" + shardId).start();
+        }
+
+        assertTrue("All threads should complete", allDone.await(30, TimeUnit.SECONDS));
+        long elapsedMs = System.currentTimeMillis() - startMs;
+        assertNull("No errors expected: " + firstError.get(), firstError.get());
+
+        // With slow upload (200ms), most concurrent shards should accumulate and batch.
+        // Expect at most 2-3 uploads (first shard dispatches immediately, remaining batch after).
+        assertTrue(
+            "Uploads (" + uploadCount.get() + ") should be much fewer than shards (" + numShards + ")",
+            uploadCount.get() < numShards
+        );
+
+        // Completion should be fast — no artificial 650ms wait added by coordinator
+        assertTrue("Should complete within 3s (actual: " + elapsedMs + "ms)", elapsedMs < 3000);
+    }
+
+    /**
+     * Proves that immediate dispatch does NOT add artificial latency.
+     * A single shard's submitAndWait() should complete in roughly the upload time,
+     * not upload time + batch interval.
+     *
+     * This is the key regression test for the double-buffering fix:
+     * Before: submitAndWait blocked for batchInterval (650ms) + upload time
+     * After:  submitAndWait blocks only for upload time
+     */
+    public void testImmediateDispatchNoArtificialLatency() throws Exception {
+        TranslogArchiveBatchCoordinator coordinator = createCoordinator();
+        TransferService transferService = mock(TransferService.class);
+
+        int uploadDelayMs = 50;
+        org.mockito.Mockito.doAnswer(inv -> {
+            Thread.sleep(uploadDelayMs);
+            return null;
+        }).when(transferService).uploadBlobStream(any(), anyLong(), any(), anyString(), any(), any());
+
+        long startMs = System.currentTimeMillis();
+        coordinator.submitAndWait(createShardData(0, "latency-test"), transferService);
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        // Should complete close to uploadDelayMs, definitely not uploadDelay + 650ms
+        // Allow generous overhead of 200ms for thread scheduling, but catch the old 650ms wait
+        assertTrue(
+            "submitAndWait should complete in ~" + uploadDelayMs + "ms, not " + elapsedMs
+                + "ms (old behavior would add ~650ms batch interval wait)",
+            elapsedMs < uploadDelayMs + 200
+        );
     }
 }


### PR DESCRIPTION

### Description
The buffered interval time has been waited on BufferedAsyncIOProcessorBatching, translog archive batch coordiantor does not need to wait for another buffer interval to batch multiple shards translogs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
